### PR TITLE
Remove Heartbeart vs Health Check IP confusion

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -42,7 +42,7 @@ If you are restricting SSH access to your server using IP whitelisting, you **mu
 - `157.245.120.132`
 - `134.122.14.47`
 
-You may also need to whitelist the [Heartbeat IP addresses](/projects/heartbeats#heartbeat-ip-addresses).
+You may also need to whitelist the [Health Check IP addresses](/projects/management.html#health-checks).
 
 ## Envoyer API
 


### PR DESCRIPTION
Heartbeats do not send requests to projects or servers, whereas Health Checks do, so Health Checks may need to be able to penetrate firewall protections for ports 80 and / or 443 (or, as a matter of fact, those ports that the web server daemon is listening to).